### PR TITLE
Improved proxy support

### DIFF
--- a/springerdl/interface/cli.py
+++ b/springerdl/interface/cli.py
@@ -39,23 +39,23 @@ class cli_main(object):
         parser.add_argument('-v', '--verbose', action="store_true", default=False,
                         help=_("Verbose stdout."))
         parser.add_argument("--proxy-url", nargs='?', const=None, default=None, 
-                            type=str, help=_("Set proxy address"))
+                            type=str, help=_("Set proxy address [default: %(default)s]"))
         parser.add_argument("--proxy-username", nargs='?', const=None, default=None, 
-                            type=str, help=_("Set username to authenticate with at proxy"))
+                            type=str, help=_("Set username to authenticate with at proxy [default: %(default)s]"))
         parser.add_argument("--proxy-password", nargs='?', const=None, default=None, 
-                            type=str, help=_("Set password to authenticate with at proxy"))
-        parser.add_argument("--proxy-realm", nargs='?', const=None, default=None, 
-                            type=str, help=_("Set authentication realm"))
+                            type=str, help=_("Set password to authenticate with at proxy [default: %(default)s]"))
+        parser.add_argument("--proxy-port", nargs='?', const=80, default=80, 
+                            type=int, help=_("Set proxy port [default: %(default)s]"))
         parser.add_argument("--user-agent", nargs='?', const=None, default=None, 
-                            type=str, help=_("Set custom user agent"))
+                            type=str, help=_("Set custom user agent [default: %(default)s]"))
         
         args = parser.parse_args()
         
         proxy = {
             "url" : args.proxy_url,
-            "realm" : args.proxy_realm,
             "username" : args.proxy_username,
             "password" : args.proxy_password,
+            "port" : args.proxy_port
         }
         
         self.options =  {

--- a/springerdl/interface/default.py
+++ b/springerdl/interface/default.py
@@ -12,6 +12,8 @@ class default_main(object):
             "skip-meta": False,
             "sorted": False,
             "output-file": None,
+            "proxy" : None,
+            "user-agent" : USER_AGENT,
         }
         
     def option(self, key):

--- a/springerdl/meta.py
+++ b/springerdl/meta.py
@@ -1,7 +1,7 @@
 
 import re, os
 
-from urllib2 import urlopen, URLError
+from urllib2 import URLError
 from httplib import BadStatusLine
 from tempfile import NamedTemporaryFile
 from subprocess import Popen, PIPE
@@ -128,7 +128,7 @@ def _tocFromDiv(div):
 
 def fetchCover(isbn,size):
     try:
-        webImg = urlopen("%s/covers/%s.tif" \
+        webImg = util.connect("%s/covers/%s.tif" \
                        % (SPR_IMG_URL,isbn))
         tmp_img    = NamedTemporaryFile(delete=False,suffix=".tif")
         tmp_pdfimg = NamedTemporaryFile(delete=False,suffix=".pdf")

--- a/springerdl/util.py
+++ b/springerdl/util.py
@@ -96,19 +96,24 @@ def decodeForSure(s):
 def setupOpener(proxy,useragent):
     if proxy:
         url = proxy["url"]
-        
+        port = proxy["port"]
         if url:
-            proxy_handler = urllib2.ProxyHandler({'http': url})
+            
+            proxy_handler = None
+            if not port:
+                proxy_handler = urllib2.ProxyHandler({'http': url})
+            else:
+                proxy_handler = urllib2.ProxyHandler({'http': "%s:%d" % (url, port)})
             
             username = proxy["username"]
             password = proxy["password"]
-            realm = proxy["realm"]
-            if username and password and realm:
-                auth_handlers = [urllib2.ProxyBasicAuthHandler(), urllib2.ProxyDigestAuthHandler()]
+            if username and password:
+                password_mgr = urllib2.HTTPPasswordMgrWithDefaultRealm()
                 
-                for auth_handler in auth_handlers:
-                    auth_handler.add_password(realm, SPRINGER_URL, username, password)
-                    auth_handler.add_password(realm, SPR_IMG_URL, username, password)
+                password_mgr.add_password(None, SPRINGER_URL, username, password)
+                password_mgr.add_password(None, SPR_IMG_URL, username, password)
+                
+                auth_handlers = [urllib2.ProxyBasicAuthHandler(password_mgr), urllib2.ProxyDigestAuthHandler(password_mgr)]
                 
                 opener = urllib2.build_opener(proxy_handler, *auth_handlers)
             else:


### PR DESCRIPTION
Hello,
the proxy support of my last commit required a realm (besides username/password) to be specified, in order to use proxy authentication. This realm parameter is now obsolete, which makes authentication much easier. Besides that i did some minor modifications.

Greetings
Jakob
